### PR TITLE
Add Embedded Institution Search

### DIFF
--- a/public/bill-details.html
+++ b/public/bill-details.html
@@ -60,15 +60,16 @@
           <div class="tab-content" id="myTabContent">
             <div class="tab-pane fade show active" id="tui" role="tabpanel" aria-labelledby="tui-tab">
               <div class="w-100 mb-4">
-                <label for="selectAccount" id="banksMsg" class="form-label
-                        ">Select an account</label>
-                <select id="selectAccount" class="form-select" aria-label="Select an account"></select>
-              </div>
-              <div class="w-100 mb-4">
                 <label for="amountToPay" class="form-label
               ">Amount to pay</label>
                 <input type="number" class="form-control" id="amountToPay" />
               </div>
+              <div class="w-100 mb-4">
+                <label for="selectAccount" id="banksMsg" class="form-label
+                        ">Select an account</label>
+                <select id="selectAccount" class="form-select" aria-label="Select an account"></select>
+              </div>
+              <div class="w-100 mb-4 d-none" style="height: 350px;" id="plaidEmbedContainer"></div>
 
               <div class="w-100 mb-4">
                 <button type="button" class="btn btn-primary text-white" id="payBill">Pay Bill</button>
@@ -76,18 +77,17 @@
             </div>
             <!-- Interface that doesn't use Transfer UI -->
             <div class="tab-pane fade" id="notui" role="tabpanel" aria-labelledby="no-tui-tab">
-
-              <div class="w-100 mb-4">
-                <label for=" selectAccount" id="banksMsgNoTUI" class="form-label
-                                    ">Select an account</label>
-                <select id="selectAccountNoTUI" class="form-select" aria-label="Select an account"></select>
-              </div>
               <div class="w-100 mb-4">
                 <label for="amountToPayNoTUI" class="form-label
                           ">Amount to pay</label>
                 <input type="number" class="form-control" id="amountToPayNoTUI" />
               </div>
-
+              <div class="w-100 mb-4">
+                <label for="selectAccount" id="banksMsgNoTUI" class="form-label
+                                    ">Select an account</label>
+                <select id="selectAccountNoTUI" class="form-select" aria-label="Select an account"></select>
+              </div>
+              <div class="w-100 mb-4 d-none" style="height: 350px;" id="plaidEmbedContainerNoTUI"></div>
               <div class="w-100 mb-4">
                 <button type="button" class="btn btn-primary text-white" id="payBillNoTUI">Pay Bill</button>
               </div>
@@ -160,6 +160,8 @@
   <script src="https://cdn.plaid.com/link/v2/stable/link-initialize.js"></script>
 
   <script type="module" src="js/bill-details.js"></script>
+  <script type="module" src="js/make-payment.js"></script>
+  <script type="module" src="js/make-payment-no-tui.js"></script>
 
 </body>
 

--- a/public/js/bill-details.js
+++ b/public/js/bill-details.js
@@ -1,5 +1,4 @@
 import { refreshSignInStatus, signOut } from "./signin.js";
-import { startLink, exchangePublicToken } from "./link.js";
 import {
   callMyServer,
   currencyAmount,
@@ -7,8 +6,8 @@ import {
   prettyDate,
   getDetailsAboutStatus,
 } from "./utils.js";
-
-let pendingPaymentObject = {};
+import { initiatePayment } from "./make-payment.js";
+import {startPaymentNoTUI, paymentDialogConfirmed} from "./make-payment-no-tui.js";
 
 /**
  * Call the server to see what banks the user is connected to.
@@ -33,186 +32,7 @@ export const getPaymentOptions = async () => {
   accountSelectNoTUI.innerHTML = innerHTML;
 };
 
-/************************
- * If you're using TransferUI (which we recommend for most developers getting started)
- * you would follow this approach.
- ***********************/
 
-/**
- * We start by sending the payment information down to the server -- the server
- * will create a Transfer Intent, and then pass that intent over to 
- * /link/token/create. So we end up with a Link token that we can use to 
- * open Link and start the payment process.
- * 
- * Note that if we don't send down an account ID to use, that's a sign to Link
- * that we'll need to connect to a bank first.
- */
-export const initiatePayment = async () => {
-  const billId = new URLSearchParams(window.location.search).get("billId");
-  const accountId = document.querySelector("#selectAccount").value;
-  const amount = document.querySelector("#amountToPay").value;
-  console.log(`Paying bill ${billId} from bank ${accountId} for $${amount}`);
-  if (billId == null || amount == null) {
-    alert("Something went wrong");
-    return;
-  }
-  if (isNaN(amount) || amount <= 0) {
-    alert("Please enter a valid amount.");
-    return;
-  }
-  const { linkToken, transferIntentId } = await callMyServer(
-    "/server/payments/initiate",
-    true,
-    {
-      billId,
-      accountId,
-      amount,
-    }
-  );
-
-  // When we're all done, we're going to send the public token and the
-  // original transfer intent ID back to the server so we can gather some
-  // information about the payment that was just created.
-  const successHandler = async (publicToken, _) => {
-    console.log("Finished with Link!");
-    if (accountId === "new") {
-      console.log(
-        "Oh! Looks like you set up a new account. Let's exchange that token!"
-      );
-      await exchangePublicToken(publicToken);
-    }
-
-    await callMyServer("/server/payments/transfer_ui_complete", true, {
-      publicToken,
-      transferIntentId,
-    });
-    await Promise.all[(getBillDetails(), getPaymentOptions())];
-  };
-  startLink(linkToken, successHandler);
-};
-
-/************************
- *
- * Not interested in using TransferUI? You would use these functions instead.
- *
- ***********************/
-
-/**
- * First, let's see if our user asked to connect to a new account. If so, we'll
- * create a link token and start the Link flow through the addNewAccount function.
- */
-const startPaymentNoTUI = async () => {
-  const accountId = document.querySelector("#selectAccountNoTUI").value;
-  if (accountId === "new") {
-    await addNewAccountThenStartPayment();
-  } else {
-    await preparePaymentDialog(accountId);
-  }
-};
-
-
-/**
- * If a user decides to add a new account, you can create a link
- * token like normal. We ask our server to return an account ID from the
- * item we just created. (Ideally, this works best if you've customized your
- * link flow so that your user selects a single account)
- */
-const addNewAccountThenStartPayment = async () => {
-  const linkTokenData = await callMyServer(
-    "/server/tokens/create_link_token",
-    true
-  );
-  startLink(linkTokenData.link_token, async (publicToken, metadata) => {
-    console.log("Finished with Link!");
-    console.log(metadata);
-    const newAccountId = await exchangePublicToken(publicToken, true);
-    await getPaymentOptions();
-    // A little hacky, but let's change the value of our drop-down so we
-    // can grab the account name later.
-    document.querySelector("#selectAccountNoTUI").value = newAccountId;
-    preparePaymentDialog(newAccountId);
-  });
-};
-
-/**
- * Next, we'll start a transfer by gathering up some information about the
- * payment and using that to populate a consent dialog.
- */
-const preparePaymentDialog = async (accountId) => {
-  const billId = new URLSearchParams(window.location.search).get("billId");
-  const amount = document.querySelector("#amountToPayNoTUI").value;
-  console.log(`Paying bill ${billId} from bank ${accountId} for $${amount}`);
-  if (billId == null || amount == null) {
-    alert("Something went wrong");
-    return;
-  }
-  if (isNaN(amount) || amount <= 0) {
-    alert("Please enter a valid amount.");
-    return;
-  }
-  if (accountId === "new") {
-    alert("Please select an account or click the 'Add new account' button.");
-    return;
-  }
-  pendingPaymentObject = { billId, accountId, amount };
-  showDialog(amount);
-};
-
-/**
- * And, here's the code to actually display the dialog.
- */
-const showDialog = async (amount) => {
-  // Set the title and message in the dialog
-  document.querySelector(
-    "#customDialogLabel"
-  ).textContent = `Confirm your ${currencyAmount(amount, "USD")} payment`;
-  document.querySelector("#dlogAccount").textContent = document.querySelector(
-    "#selectAccountNoTUI"
-  ).selectedOptions[0].textContent;
-
-  document.querySelector("#dlogDate").textContent = prettyDate(
-    new Date().toLocaleString()
-  );
-  // Show the modal
-  var myModal = new bootstrap.Modal(document.getElementById("customDialog"), {
-    keyboard: false,
-  });
-  myModal.show();
-};
-
-/**
- * If the user clicks "Confirm", we're going to store the proof of authorization
- * data necessary for Nacha compliance and then authorize and create the payment.
- *
- * You would do probably this in a single endpoint call, but we'm breaking it 
- * out into two separate calls so you don't overlook this important step.
- */
-const paymentDialogConfirmed = async () => {
-  await callMyServer(
-    "/server/payments/no_transfer_ui/store_proof_of_authorization_necessary_for_nacha_compliance",
-    true,
-    {
-      billId: pendingPaymentObject.billId,
-      accountId: pendingPaymentObject.accountId,
-      amount: pendingPaymentObject.amount,
-    }
-  );
-  const { status, message } = await callMyServer(
-    "/server/payments/no_transfer_ui/authorize_and_create",
-    true,
-    {
-      billId: pendingPaymentObject.billId,
-      accountId: pendingPaymentObject.accountId,
-      amount: pendingPaymentObject.amount,
-    }
-  );
-  if (status === "success") {
-    await getBillDetails();
-  } else {
-    alert(message);
-    await getBillDetails();
-  }
-};
 
 /**
  * Retrieve the list of payments for a bill and update the table.
@@ -251,7 +71,7 @@ export const paymentsRefresh = async (billId) => {
 /**
  * Retrieve the details of the current bill and update the interface
  */
-const getBillDetails = async () => {
+export const getBillDetails = async () => {
   console.log("Getting bill details");
   // Grab the bill ID from the url argument
   const urlParams = new URLSearchParams(window.location.search);
@@ -325,7 +145,6 @@ const signedInCallBack = (userInfo) => {
   getPaymentOptions();
 };
 
-
 /**
  * Connects the buttons on the page to the functions above.
  */
@@ -345,6 +164,7 @@ Object.entries(selectorsAndFunctions).forEach(([sel, fun]) => {
     document.querySelector(sel)?.addEventListener("click", fun);
   }
 });
+
 
 /**
  * Enable Bootstrap tooltips

--- a/public/js/bill-details.js
+++ b/public/js/bill-details.js
@@ -6,8 +6,8 @@ import {
   prettyDate,
   getDetailsAboutStatus,
 } from "./utils.js";
-import { initiatePayment } from "./make-payment.js";
-import {startPaymentNoTUI, paymentDialogConfirmed} from "./make-payment-no-tui.js";
+import { initiatePaymentWasClicked } from "./make-payment.js";
+import { startPaymentNoTUIWasClicked, paymentDialogConfirmed } from "./make-payment-no-tui.js";
 
 /**
  * Call the server to see what banks the user is connected to.
@@ -150,10 +150,10 @@ const signedInCallBack = (userInfo) => {
  */
 const selectorsAndFunctions = {
   "#signOut": () => signOut(signedOutCallBack),
-  "#payBill": initiatePayment,
+  "#payBill": initiatePaymentWasClicked,
   "#syncServer": performServerSync,
   "#fireWebhook": fireTestWebhook,
-  "#payBillNoTUI": startPaymentNoTUI,
+  "#payBillNoTUI": startPaymentNoTUIWasClicked,
   "#dlogConfirmBtn": paymentDialogConfirmed,
 };
 

--- a/public/js/link.js
+++ b/public/js/link.js
@@ -25,6 +25,28 @@ export const startLink = async function (linkToken, asyncCustomSuccessHandler) {
   handler.open();
 };
 
+export const startEmbeddedLink = async function (linkToken, asyncCustomSuccessHandler, targetDiv) {
+  const handler = Plaid.createEmbedded({
+    token: linkToken,
+    onSuccess: async (publicToken, metadata) => {
+      console.log(`Finished with Link! ${JSON.stringify(metadata)}`);
+      await asyncCustomSuccessHandler(publicToken, metadata);
+    },
+    onExit: async (err, metadata) => {
+      console.log(
+        `Exited early. Error: ${JSON.stringify(err)} Metadata: ${JSON.stringify(
+          metadata
+        )}`
+      );
+    },
+    onEvent: (eventName, metadata) => {
+      console.log(`Event ${eventName}, Metadata: ${JSON.stringify(metadata)}`);
+    },
+  },
+  targetDiv);
+};
+
+
 /**
  * Exchange our Link token data for an access token
  */

--- a/public/js/link.js
+++ b/public/js/link.js
@@ -25,6 +25,17 @@ export const startLink = async function (linkToken, asyncCustomSuccessHandler) {
   handler.open();
 };
 
+/**
+ * This starts Link Embedded Institution Search (which we usually just call 
+ * Embedded Link) -- instead of initiating Link in a separate dialog box, we
+ * start by displaying the "Search for your bank" content in the page itself, 
+ * then switch to the Link dialog after the user selects their bank. This 
+ * tends to increase uptake on pay-by-bank flows. 
+ * 
+ * If you don't want to use Embedded Link, you can always use the startLink
+ * function instead to start link the traditional way.
+ * 
+ */
 export const startEmbeddedLink = async function (linkToken, asyncCustomSuccessHandler, targetDiv) {
   const handler = Plaid.createEmbedded({
     token: linkToken,
@@ -43,7 +54,7 @@ export const startEmbeddedLink = async function (linkToken, asyncCustomSuccessHa
       console.log(`Event ${eventName}, Metadata: ${JSON.stringify(metadata)}`);
     },
   },
-  targetDiv);
+    targetDiv);
 };
 
 

--- a/public/js/make-payment-no-tui.js
+++ b/public/js/make-payment-no-tui.js
@@ -1,0 +1,167 @@
+
+import { startLink, exchangePublicToken, startEmbeddedLink } from "./link.js";
+import { showSelector, hideSelector, callMyServer, currencyAmount , prettyDate} from "./utils.js";
+import { getBillDetails, getPaymentOptions } from "./bill-details.js";
+
+
+/************************
+ *
+ * Not interested in using TransferUI? You would use these functions instead.
+ *
+ ***********************/
+
+let pendingPaymentObject = {};
+
+
+const shouldIShowEmbeddedLinkNoTUI = () => {
+  if (document.querySelector("#selectAccountNoTUI").value === "new" &&
+  document.querySelector("#amountToPayNoTUI").value > 0) {
+    showSelector("#plaidEmbedContainerNoTUI");
+    hideSelector("#payBillNoTUI");
+    prepareEmbedContainerNoTUI();
+  } else {
+    hideSelector("#plaidEmbedContainerNoTUI");
+    showSelector("#payBillNoTUI");
+  }
+}
+
+
+const prepareEmbedContainerNoTUI = async () => {
+  const linkTokenData = await callMyServer(
+    "/server/tokens/create_link_token",
+    true
+  );
+  const successHandler = async (publicToken, metadata) => {
+    console.log("Finished with Link!");
+    console.log(metadata);
+    const newAccountId = await exchangePublicToken(publicToken, true);
+    await getPaymentOptions();
+    // A little hacky, but let's change the value of our drop-down so we
+    // can grab the account name later.
+    document.querySelector("#selectAccountNoTUI").value = newAccountId;
+    preparePaymentDialog(newAccountId);
+  }
+  const targetElement = document.querySelector("#plaidEmbedContainerNoTUI");
+  startEmbeddedLink(linkTokenData.link_token, successHandler, targetElement);
+};
+
+/**
+ * First, let's see if our user asked to connect to a new account. If so, we'll
+ * create a link token and start the Link flow through the addNewAccount function.
+ */
+export const startPaymentNoTUI = async () => {
+  const accountId = document.querySelector("#selectAccountNoTUI").value;
+  if (accountId === "new") {
+    await addNewAccountThenStartPayment();
+  } else {
+    await preparePaymentDialog(accountId);
+  }
+};
+
+
+/**
+ * If a user decides to add a new account, you can create a link
+ * token like normal. We ask our server to return an account ID from the
+ * item we just created. (Ideally, this works best if you've customized your
+ * link flow so that your user selects a single account)
+ */
+const addNewAccountThenStartPayment = async () => {
+  const linkTokenData = await callMyServer(
+    "/server/tokens/create_link_token",
+    true
+  );
+  startLink(linkTokenData.link_token, async (publicToken, metadata) => {
+    console.log("Finished with Link!");
+    console.log(metadata);
+    const newAccountId = await exchangePublicToken(publicToken, true);
+    await getPaymentOptions();
+    // A little hacky, but let's change the value of our drop-down so we
+    // can grab the account name later.
+    document.querySelector("#selectAccountNoTUI").value = newAccountId;
+    preparePaymentDialog(newAccountId);
+  });
+};
+
+/**
+ * Next, we'll start a transfer by gathering up some information about the
+ * payment and using that to populate a consent dialog.
+ */
+ const preparePaymentDialog = async (accountId) => {
+  const billId = new URLSearchParams(window.location.search).get("billId");
+  const amount = document.querySelector("#amountToPayNoTUI").value;
+  console.log(`Paying bill ${billId} from bank ${accountId} for $${amount}`);
+  if (billId == null || amount == null) {
+    alert("Something went wrong");
+    return;
+  }
+  if (isNaN(amount) || amount <= 0) {
+    alert("Please enter a valid amount.");
+    return;
+  }
+  if (accountId === "new") {
+    alert("Please select an account or click the 'Add new account' button.");
+    return;
+  }
+  pendingPaymentObject = { billId, accountId, amount };
+  showDialog(amount);
+};
+
+/**
+ * And, here's the code to actually display the dialog.
+ */
+const showDialog = async (amount) => {
+  // Set the title and message in the dialog
+  document.querySelector(
+    "#customDialogLabel"
+  ).textContent = `Confirm your ${currencyAmount(amount, "USD")} payment`;
+  document.querySelector("#dlogAccount").textContent = document.querySelector(
+    "#selectAccountNoTUI"
+  ).selectedOptions[0].textContent;
+
+  document.querySelector("#dlogDate").textContent = prettyDate(
+    new Date().toLocaleString()
+  );
+  // Show the modal
+  var myModal = new bootstrap.Modal(document.getElementById("customDialog"), {
+    keyboard: false,
+  });
+  myModal.show();
+};
+
+/**
+ * If the user clicks "Confirm", we're going to store the proof of authorization
+ * data necessary for Nacha compliance and then authorize and create the payment.
+ *
+ * You would do probably this in a single endpoint call, but we'm breaking it 
+ * out into two separate calls so you don't overlook this important step.
+ */
+export const paymentDialogConfirmed = async () => {
+  await callMyServer(
+    "/server/payments/no_transfer_ui/store_proof_of_authorization_necessary_for_nacha_compliance",
+    true,
+    {
+      billId: pendingPaymentObject.billId,
+      accountId: pendingPaymentObject.accountId,
+      amount: pendingPaymentObject.amount,
+    }
+  );
+  const { status, message } = await callMyServer(
+    "/server/payments/no_transfer_ui/authorize_and_create",
+    true,
+    {
+      billId: pendingPaymentObject.billId,
+      accountId: pendingPaymentObject.accountId,
+      amount: pendingPaymentObject.amount,
+    }
+  );
+  if (status === "success") {
+    await getBillDetails();
+  } else {
+    alert(message);
+    await getBillDetails();
+  }
+};
+
+// Let's also set up the embedded link container logic
+document.querySelector("#selectAccountNoTUI").addEventListener("change", shouldIShowEmbeddedLinkNoTUI);
+document.querySelector("#amountToPayNoTUI").addEventListener("change", shouldIShowEmbeddedLinkNoTUI);

--- a/public/js/make-payment.js
+++ b/public/js/make-payment.js
@@ -7,21 +7,31 @@ import { getBillDetails, getPaymentOptions } from "./bill-details.js";
  * you would follow this approach.
  ***********************/
 
-const shouldIShowEmbeddedLink = () => { 
+/**
+ * We can show the embedded link UI if you want to connect to a new account.
+ * Since the TransferUI flow requires defining the transfer amount as well, 
+ * we won't show the embedded link UI until the has also entered an amount.
+ */
+const shouldIShowEmbeddedLink = () => {
   if (document.querySelector("#selectAccount").value === "new" &&
-  document.querySelector("#amountToPay").value > 0) {
+    document.querySelector("#amountToPay").value > 0) {
     showSelector("#plaidEmbedContainer");
     hideSelector("#payBill");
-    actuallyInitiatePayment(true);
+    initiatePayment(true);
   } else {
     hideSelector("#plaidEmbedContainer");
     showSelector("#payBill");
   }
 }
 
-
-export const initiatePayment = async (_) => {
-  actuallyInitiatePayment(false);
+/**
+ * The button that initiates this event will only appear if the user has 
+ * selected a pre-existing account (and entered an amount to pay). So we
+ * will skip the embedded Link portion and just bring up the Transfer UI "confirm"
+ * dialog.
+ */
+export const initiatePaymentWasClicked = async (_) => {
+  initiatePayment(false);
 }
 
 /**
@@ -33,8 +43,8 @@ export const initiatePayment = async (_) => {
  * Note that if we don't send down an account ID to use, that's a sign to Link
  * that we'll need to connect to a bank first.
  */
-export const actuallyInitiatePayment = async (useEmbeddedSearch = false) => {
-  console.log(`Starting payment, but embedded search is ${useEmbeddedSearch }`)
+export const initiatePayment = async (useEmbeddedSearch = false) => {
+  console.log(`Starting payment, but embedded search is ${useEmbeddedSearch}`)
   const billId = new URLSearchParams(window.location.search).get("billId");
   const accountId = document.querySelector("#selectAccount").value;
   const amount = document.querySelector("#amountToPay").value;
@@ -79,7 +89,7 @@ export const actuallyInitiatePayment = async (useEmbeddedSearch = false) => {
     const targetElement = document.querySelector("#plaidEmbedContainer");
     startEmbeddedLink(linkToken, successHandler, targetElement);
   } else {
-   startLink(linkToken, successHandler);
+    startLink(linkToken, successHandler);
   }
 };
 

--- a/public/js/make-payment.js
+++ b/public/js/make-payment.js
@@ -1,0 +1,87 @@
+import { startLink, exchangePublicToken, startEmbeddedLink } from "./link.js";
+import { showSelector, hideSelector, callMyServer } from "./utils.js";
+import { getBillDetails, getPaymentOptions } from "./bill-details.js";
+
+/************************
+ * If you're using TransferUI (which we recommend for most developers getting started)
+ * you would follow this approach.
+ ***********************/
+
+const shouldIShowEmbeddedLink = () => { 
+  if (document.querySelector("#selectAccount").value === "new" &&
+  document.querySelector("#amountToPay").value > 0) {
+    showSelector("#plaidEmbedContainer");
+    hideSelector("#payBill");
+    actuallyInitiatePayment(true);
+  } else {
+    hideSelector("#plaidEmbedContainer");
+    showSelector("#payBill");
+  }
+}
+
+
+export const initiatePayment = async (_) => {
+  actuallyInitiatePayment(false);
+}
+
+/**
+ * We start by sending the payment information down to the server -- the server
+ * will create a Transfer Intent, and then pass that intent over to 
+ * /link/token/create. So we end up with a Link token that we can use to 
+ * open Link and start the payment process.
+ * 
+ * Note that if we don't send down an account ID to use, that's a sign to Link
+ * that we'll need to connect to a bank first.
+ */
+export const actuallyInitiatePayment = async (useEmbeddedSearch = false) => {
+  console.log(`Starting payment, but embedded search is ${useEmbeddedSearch }`)
+  const billId = new URLSearchParams(window.location.search).get("billId");
+  const accountId = document.querySelector("#selectAccount").value;
+  const amount = document.querySelector("#amountToPay").value;
+  console.log(`Paying bill ${billId} from bank ${accountId} for $${amount}`);
+  if (billId == null || amount == null) {
+    alert("Something went wrong");
+    return;
+  }
+  if (isNaN(amount) || amount <= 0) {
+    alert("Please enter a valid amount.");
+    return;
+  }
+  const { linkToken, transferIntentId } = await callMyServer(
+    "/server/payments/initiate",
+    true,
+    {
+      billId,
+      accountId,
+      amount,
+    }
+  );
+
+  // When we're all done, we're going to send the public token and the
+  // original transfer intent ID back to the server so we can gather some
+  // information about the payment that was just created.
+  const successHandler = async (publicToken, _) => {
+    console.log("Finished with Link!");
+    if (accountId === "new") {
+      console.log(
+        "Oh! Looks like you set up a new account. Let's exchange that token!"
+      );
+      await exchangePublicToken(publicToken);
+    }
+
+    await callMyServer("/server/payments/transfer_ui_complete", true, {
+      publicToken,
+      transferIntentId,
+    });
+    await Promise.all[(getBillDetails(), getPaymentOptions())];
+  };
+  if (useEmbeddedSearch) {
+    const targetElement = document.querySelector("#plaidEmbedContainer");
+    startEmbeddedLink(linkToken, successHandler, targetElement);
+  } else {
+   startLink(linkToken, successHandler);
+  }
+};
+
+document.querySelector("#selectAccount").addEventListener("change", shouldIShowEmbeddedLink);
+document.querySelector("#amountToPay").addEventListener("change", shouldIShowEmbeddedLink);


### PR DESCRIPTION
So, we've done two things here:

1. If you're in a payment flow that requires connecting to a new bank, we'll use Embedded Link so that we can show the embedded institution search flow. This works both in Transfer UI and the non-transfer UI flow. 

2. However, the code for this started to get messy, so I broke it up into three files. bill-details now contains mostly the code for generating the details about the bill and payment statuses. make-payment not contains code to generate a payment using transfer UI, and make-payment-no-tui contains code to generate  a payment not using transfer UI

I'd love to get this reviewed for correctness, but also want to make sure this doesn't feel like it's too confusing. 