### PR TITLE
Update repository URL to public GitHub

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.plaid.com/plaid/base-sample-app"
+    "url": "https://github.com/plaid/transfer-quickstart"
   },
   "author": "Todd Kerpelman",
   "license": "ISC",


### PR DESCRIPTION
The \`repository.url\` field in \`package.json\` pointed at \`github.plaid.com/plaid/base-sample-app\` — an internal hostname leaked into a public repo. Update it to the public mirror at \`github.com/plaid/transfer-quickstart\`.

Found while auditing public sample apps for stale/leaked references.

Claude Session: 840e8428-450d-4184-8201-7392bd607741