### PR TITLE
Fix stale README references, Node version, and license

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ and
 
 # Installation
 
-We recommend having node version 18.x.x or later before attempting to run this
+We recommend having node version 20.17.x or later before attempting to run this
 application.
 
 ## 1. Make sure you have access to Transfer
@@ -468,15 +468,19 @@ Plaid Transfer.
   one _without_ using Link's Transfer UI.
 - **`/routes/payments.js`** -- List payments, create a Transfer Intent, and
   create a payment using Link's Transfer UI.
-- **`/routes/token.js`** -- Create a link token, exchange a public token for an
+- **`/routes/tokens.js`** -- Create a link token, exchange a public token for an
   access token, also does all the work around fetching and saving bank names
-- `/routes/user.js` -- Sign in, sign out, create user, etc.
+- `/routes/users.js` -- Sign in, sign out, create user, etc.
 
 ### Files On the client
 
 - **`js/bill-details.js`** -- Does much more than get bill details! This
   performs the client logic necessary to pay bills, both with and without
   Transfer UI. We should probably rename or split up this file.
+- `js/make-payment.js` -- Client logic for making a payment using Link's Transfer
+  UI
+- `js/make-payment-no-tui.js` -- Client logic for making a payment _without_
+  Link's Transfer UI
 - `js/client-bills.js` -- Fetches and displays info about the user's bills
 - `js/home.js` -- Handle creating and signing in users
 - `js/link.js` -- Initialize and run Link, send the public token down to the

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/plaid/transfer-quickstart"
   },
   "author": "Todd Kerpelman",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "body-parser": "^2.2.2",
     "bootstrap": "^5.3.8",


### PR DESCRIPTION
The README documented server routes as `token.js`/`user.js`, but the files are `tokens.js`/`users.js`, and the two `make-payment` client files were undocumented. Also corrects the stated Node minimum and the license.

- `/routes/token.js` → `/routes/tokens.js`, `/routes/user.js` → `/routes/users.js`
- Document `js/make-payment.js` and `js/make-payment-no-tui.js`
- Node minimum 18.x → 20.17.x (`sqlite3@^6.0.1` requires Node ≥20.17.0)
- `package.json` license `ISC` → `MIT`, matching the actual `LICENSE` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)