### PR TITLE
Fix six correctness bugs found in a code audit

### DIFF
--- a/public/js/make-payment.js
+++ b/public/js/make-payment.js
@@ -83,7 +83,7 @@ export const initiatePayment = async (useEmbeddedSearch = false) => {
       publicToken,
       transferIntentId,
     });
-    await Promise.all[(getBillDetails(), getPaymentOptions())];
+    await Promise.all([getBillDetails(), getPaymentOptions()]);
   };
   if (useEmbeddedSearch) {
     const targetElement = document.querySelector("#plaidEmbedContainer");

--- a/server/db.js
+++ b/server/db.js
@@ -198,6 +198,19 @@ const addBankNameForItem = async function (itemId, institutionName) {
   }
 };
 
+const deactivateItem = async function (itemId) {
+  try {
+    const result = await db.run(
+      `UPDATE items SET is_active = 0 WHERE id = ?`,
+      itemId
+    );
+    return result;
+  } catch (error) {
+    console.error(`Error deactivating item ${error}`);
+    throw error;
+  }
+};
+
 const addAccount = async function (accountId, itemId, acctName, balance) {
   try {
     await db.run(
@@ -641,6 +654,7 @@ module.exports = {
   getBankNamesForUser,
   addItem,
   addBankNameForItem,
+  deactivateItem,
   addAccount,
   createNewBill,
   getBillsForUser,

--- a/server/routes/payments_no_transferUI.js
+++ b/server/routes/payments_no_transferUI.js
@@ -2,6 +2,7 @@ const express = require("express");
 const { plaidClient } = require("../plaid");
 const db = require("../db");
 const authenticate = require("../middleware/authenticate");
+const { PAYMENT_STATUS } = require("../types");
 
 const router = express.Router();
 router.use(authenticate);
@@ -90,6 +91,15 @@ router.post("/authorize_and_create", async (req, res, next) => {
       paymentId
     );
     if (authStatus === "rejected") {
+      // The authorization was declined, so no transfer will ever be created
+      // for this payment. Mark it as denied so it doesn't sit at
+      // "waiting_for_auth" forever.
+      await db.updatePaymentWithTransferInfo(
+        paymentId,
+        null,
+        PAYMENT_STATUS.DENIED,
+        decisionMessage
+      );
       res.json({
         status: "rejected",
         message: decisionMessage,

--- a/server/routes/tokens.js
+++ b/server/routes/tokens.js
@@ -49,6 +49,11 @@ router.post("/exchange_public_token", async (req, res, next) => {
         access_token: tokenData.access_token,
       });
       const acctsData = acctsResponse.data;
+      if (acctsData.accounts.length === 0) {
+        throw new Error(
+          `No accounts were returned for item ${tokenData.item_id}`
+        );
+      }
       accountId = acctsData.accounts[0].account_id;
     }
 

--- a/server/syncPaymentData.js
+++ b/server/syncPaymentData.js
@@ -71,7 +71,7 @@ const processPaymentEvent = async (event) => {
   const paymentId = existingPayment.id;
   const billId = existingPayment.bill_id;
 
-  if (!(event.event_type in PAYMENT_STATUS)) {
+  if (!Object.values(PAYMENT_STATUS).includes(event.event_type)) {
     console.error(`Unknown event type ${event.event_type}`);
     return;
   }

--- a/server/syncPaymentData.js
+++ b/server/syncPaymentData.js
@@ -71,7 +71,7 @@ const processPaymentEvent = async (event) => {
   const paymentId = existingPayment.id;
   const billId = existingPayment.bill_id;
 
-  if (!event.event_type in PAYMENT_STATUS) {
+  if (!(event.event_type in PAYMENT_STATUS)) {
     console.error(`Unknown event type ${event.event_type}`);
     return;
   }

--- a/server/webhookServer.js
+++ b/server/webhookServer.js
@@ -96,7 +96,12 @@ function handleTransferWebhook(code, requestBody) {
   switch (code) {
     case "TRANSFER_EVENTS_UPDATE":
       console.log(`Looks like we have some new transfer events to process`);
-      syncPaymentData();
+      // We don't await this so that we can ack the webhook to Plaid quickly,
+      // but we still need to catch any error so it doesn't become an
+      // unhandled promise rejection.
+      syncPaymentData().catch((error) => {
+        console.error(`Error syncing payment data: ${error}`);
+      });
       break;
     case "RECURRING_NEW_TRANSFER":
     case "RECURRING_TRANSFER_SKIPPED":


### PR DESCRIPTION
An audit of the app turned up several logic bugs that break flows a developer copying this quickstart would actually hit.

- `server/db.js`: add missing `deactivateItem`, which `routes/banks.js` already called — `/server/banks/deactivate` threw after the item was already removed from Plaid, leaving the local DB out of sync.
- `server/syncPaymentData.js`: fix `if (!event.event_type in PAYMENT_STATUS)`, which had two stacked bugs — operator precedence made the guard always evaluate `false`, and even corrected it was checking `event_type` against the enum's uppercase *keys* instead of its lowercase *values*, so no real Plaid event would ever match. Now compares against `Object.values(PAYMENT_STATUS)`.
- `server/webhookServer.js`: catch errors from the fire-and-forget `syncPaymentData()` call in the `TRANSFER_EVENTS_UPDATE` handler so they don't surface as unhandled promise rejections.
- `server/routes/payments_no_transferUI.js`: when a transfer authorization is rejected, mark the payment `DENIED` instead of leaving it stuck at `waiting_for_auth` forever with no transfer ever created.
- `server/routes/tokens.js`: guard against an empty `accounts` array from `/accounts/get` in `exchange_public_token` instead of throwing on `accounts[0]`.
- `public/js/make-payment.js`: fix `Promise.all[(getBillDetails(), getPaymentOptions())]`, a bracket/paren typo that skipped `Promise.all` entirely (comma operator + property access instead of a function call).

Verified with an ad-hoc integration harness exercising the real modules end-to-end (Plaid network calls stubbed, everything else real — sqlite, Express routers, the actual webhook/sync code paths).